### PR TITLE
Allow version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "~2.3|~3.0",
-        "mhor/php-mediainfo" : "~1.0"
+        "mhor/php-mediainfo" : "~1.0 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "@stable",

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.3|~3.0",
-        "mhor/php-mediainfo" : "~1.0 || ^2.0"
+        "symfony/framework-bundle": "^2.3 || ^3.0",
+        "mhor/php-mediainfo" : "^1.0 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "@stable",


### PR DESCRIPTION
I can't see any BC-break between version 1 and 2, so why not?